### PR TITLE
Add UTXOAirdropBadge Testnet deployment information

### DIFF
--- a/packages/ckb/src/constants/index.ts
+++ b/packages/ckb/src/constants/index.ts
@@ -160,6 +160,12 @@ const TestnetInfo = {
     outPoint: { txHash: '0xfa0a6821293cc1ef4ee67a900862208e27f67b98237c9b13bf93c84607c5cd33', index: '0x2' },
     depType: 'code',
   } as CKBComponents.CellDep,
+
+  TokenMetadataTypeScript: {
+    codeHash: '0x0c7dc8caec145b51b142e13f47fe4262c80628213d1b6c3d9c1aa6a62088804e',
+    hashType: 'type',
+    args: '',
+  } as CKBComponents.Script,
 };
 
 const MainnetInfo = {
@@ -279,6 +285,13 @@ const MainnetInfo = {
     outPoint: { txHash: '0xfa0a6821293cc1ef4ee67a900862208e27f67b98237c9b13bf93c84607c5cd33', index: '0x2' },
     depType: 'code',
   } as CKBComponents.CellDep,
+
+  // TODO: Update the TokenMetadataTypeScript after the mainnet deployment
+  TokenMetadataTypeScript: {
+    codeHash: '0x0c7dc8caec145b51b142e13f47fe4262c80628213d1b6c3d9c1aa6a62088804e',
+    hashType: 'type',
+    args: '',
+  } as CKBComponents.Script,
 };
 
 export const UNLOCKABLE_LOCK_SCRIPT = {
@@ -357,3 +370,6 @@ export const getUtxoAirdropBadgeTypeScript = (isMainnet: boolean) =>
   isMainnet ? MainnetInfo.UtxoAirdropBadgeTypeScript : TestnetInfo.UtxoAirdropBadgeTypeScript;
 export const getUtxoAirdropBadgeTypeDep = (isMainnet: boolean) =>
   isMainnet ? MainnetInfo.UtxoAirdropBadgeTypeDep : TestnetInfo.UtxoAirdropBadgeTypeDep;
+
+export const getTokenMetadataTypeScript = (isMainnet: boolean) =>
+  isMainnet ? MainnetInfo.TokenMetadataTypeScript : TestnetInfo.TokenMetadataTypeScript;

--- a/packages/ckb/src/constants/index.ts
+++ b/packages/ckb/src/constants/index.ts
@@ -268,7 +268,7 @@ const MainnetInfo = {
     depType: 'code',
   } as CKBComponents.CellDep,
 
-  // TODO: Update the UtxoAirdropBadgeTypeScript code hash after the mainnet deployment
+  // TODO: Update the UtxoAirdropBadgeTypeScript and UtxoAirdropBadgeTypeDep after the mainnet deployment
   UtxoAirdropBadgeTypeScript: {
     codeHash: '0xf5da9003e31fa9301a3915fe304de9bdb80524b5f0d8fc325fb699317998ee7a',
     hashType: 'type',

--- a/packages/ckb/src/constants/index.ts
+++ b/packages/ckb/src/constants/index.ts
@@ -149,6 +149,17 @@ const TestnetInfo = {
     outPoint: { txHash: '0x5364b3535965e9eac9a35dd7af8e9e45a61d30a16e115923c032f80b28783e21', index: '0x1' },
     depType: 'code',
   } as CKBComponents.CellDep,
+
+  UtxoAirdropBadgeTypeScript: {
+    codeHash: '0xf5da9003e31fa9301a3915fe304de9bdb80524b5f0d8fc325fb699317998ee7a',
+    hashType: 'type',
+    args: '',
+  } as CKBComponents.Script,
+
+  UtxoAirdropBadgeTypeDep: {
+    outPoint: { txHash: '0xfa0a6821293cc1ef4ee67a900862208e27f67b98237c9b13bf93c84607c5cd33', index: '0x2' },
+    depType: 'code',
+  } as CKBComponents.CellDep,
 };
 
 const MainnetInfo = {
@@ -256,6 +267,18 @@ const MainnetInfo = {
     },
     depType: 'code',
   } as CKBComponents.CellDep,
+
+  // TODO: Update the UtxoAirdropBadgeTypeScript code hash after the mainnet deployment
+  UtxoAirdropBadgeTypeScript: {
+    codeHash: '0xf5da9003e31fa9301a3915fe304de9bdb80524b5f0d8fc325fb699317998ee7a',
+    hashType: 'type',
+    args: '',
+  } as CKBComponents.Script,
+
+  UtxoAirdropBadgeTypeDep: {
+    outPoint: { txHash: '0xfa0a6821293cc1ef4ee67a900862208e27f67b98237c9b13bf93c84607c5cd33', index: '0x2' },
+    depType: 'code',
+  } as CKBComponents.CellDep,
 };
 
 export const UNLOCKABLE_LOCK_SCRIPT = {
@@ -329,3 +352,8 @@ export const getSporeTypeDep = (isMainnet: boolean) =>
 
 export const getCompatibleXudtTypeScripts = (isMainnet: boolean) =>
   isMainnet ? MainnetInfo.CompatibleXUDTTypeScripts : TestnetInfo.CompatibleXUDTTypeScripts;
+
+export const getUtxoAirdropBadgeTypeScript = (isMainnet: boolean) =>
+  isMainnet ? MainnetInfo.UtxoAirdropBadgeTypeScript : TestnetInfo.UtxoAirdropBadgeTypeScript;
+export const getUtxoAirdropBadgeTypeDep = (isMainnet: boolean) =>
+  isMainnet ? MainnetInfo.UtxoAirdropBadgeTypeDep : TestnetInfo.UtxoAirdropBadgeTypeDep;

--- a/packages/ckb/src/utils/cell-dep.spec.ts
+++ b/packages/ckb/src/utils/cell-dep.spec.ts
@@ -69,4 +69,13 @@ describe('dynamic fetch cell dep', () => {
     expect(cellDeps[0].outPoint?.txHash).toBe('0xed7d65b9ad3d99657e37c4285d585fea8a5fcaf58165d54dacf90243f911548b');
     expect(cellDeps[0].outPoint?.index).toBe('0x0');
   });
+
+  it('fetchTypeIdCellDeps with UTXOAirdropBadge', async () => {
+    const isMainnet = false;
+    const cellDeps = await fetchTypeIdCellDeps(isMainnet, {
+      utxoAirdropBadge: true,
+    });
+    expect(cellDeps[0].outPoint?.txHash).toBe('0xfa0a6821293cc1ef4ee67a900862208e27f67b98237c9b13bf93c84607c5cd33');
+    expect(cellDeps[0].outPoint?.index).toBe('0x2');
+  });
 });

--- a/packages/ckb/src/utils/cell-dep.ts
+++ b/packages/ckb/src/utils/cell-dep.ts
@@ -1,5 +1,11 @@
 import axios from 'axios';
-import { getBtcTimeLockDep, getRgbppLockDep, getUniqueTypeDep, getXudtDep } from '../constants';
+import {
+  getBtcTimeLockDep,
+  getRgbppLockDep,
+  getUniqueTypeDep,
+  getUtxoAirdropBadgeTypeDep,
+  getXudtDep,
+} from '../constants';
 import { BTCTestnetType } from '../types';
 
 interface CellDepsObject {
@@ -19,6 +25,10 @@ interface CellDepsObject {
   unique: {
     testnet: CKBComponents.CellDep;
   };
+  utxoAirdropBadge: {
+    testnet: CKBComponents.CellDep;
+    mainnet: CKBComponents.CellDep;
+  };
   compatibleXudt: {
     [codeHash: string]: CKBComponents.CellDep;
   };
@@ -31,14 +41,37 @@ const GITHUB_CELL_DEPS_JSON_URL =
 const CDN_GITHUB_CELL_DEPS_JSON_URL =
   'https://cdn.jsdelivr.net/gh/utxostack/typeid-contract-cell-deps@main/deployment/cell-deps.json';
 
+const VERCEL_CELL_DEPS_JSON_STATIC_URL = 'https://typeid-contract-cell-deps.vercel.app/deployment/cell-deps.json';
+
+const VERCEL_SERVER_CELL_DEPS_JSON_URL = 'https://typeid-contract-cell-deps.vercel.app/api/cell-deps';
+
 const request = (url: string) => axios.get(url, { timeout: 5000 });
+
+const fetchCellDepsJsonFromStaticSource = async () => {
+  try {
+    const response = await Promise.any([
+      request(CDN_GITHUB_CELL_DEPS_JSON_URL),
+      request(GITHUB_CELL_DEPS_JSON_URL),
+      request(VERCEL_CELL_DEPS_JSON_STATIC_URL),
+    ]);
+    return response.data as CellDepsObject;
+  } catch (error) {
+    // for (const e of error.errors) {
+    //   console.error('Error fetching cell deps from static source:', e);
+    // }
+  }
+};
 
 const fetchCellDepsJson = async () => {
   try {
-    const response = await Promise.any([request(CDN_GITHUB_CELL_DEPS_JSON_URL), request(GITHUB_CELL_DEPS_JSON_URL)]);
-    return response.data as CellDepsObject;
+    const response = await request(VERCEL_SERVER_CELL_DEPS_JSON_URL);
+    if (response && response.data) {
+      return response.data as CellDepsObject;
+    }
+    return await fetchCellDepsJsonFromStaticSource();
   } catch (error) {
-    // console.error('Error fetching cell deps:', error);
+    // console.error('Error fetching cell deps from vercel server:', error);
+    return await fetchCellDepsJsonFromStaticSource();
   }
 };
 
@@ -48,6 +81,7 @@ export interface CellDepsSelected {
   xudt?: boolean;
   unique?: boolean;
   compatibleXudtCodeHashes?: string[];
+  utxoAirdropBadge?: boolean;
 }
 
 export const fetchTypeIdCellDeps = async (
@@ -61,23 +95,19 @@ export const fetchTypeIdCellDeps = async (
   let btcTimeDep = getBtcTimeLockDep(isMainnet, btcTestnetType);
   let xudtDep = getXudtDep(isMainnet);
   let uniqueDep = getUniqueTypeDep(isMainnet);
+  let utxoAirdropBadgeDep = getUtxoAirdropBadgeTypeDep(isMainnet);
 
   const cellDepsObj = await fetchCellDepsJson();
-  if (cellDepsObj) {
-    if (btcTestnetType === 'Signet') {
-      rgbppLockDep = cellDepsObj.rgbpp.signet;
-      btcTimeDep = cellDepsObj.btcTime.signet;
-    } else {
-      rgbppLockDep = isMainnet ? cellDepsObj.rgbpp.mainnet : cellDepsObj.rgbpp.testnet;
-      btcTimeDep = isMainnet ? cellDepsObj.btcTime.mainnet : cellDepsObj.btcTime.testnet;
-    }
-    if (!isMainnet) {
-      xudtDep = cellDepsObj.xudt.testnet;
-      uniqueDep = cellDepsObj.unique.testnet;
-    }
-  }
 
   if (selected.rgbpp === true) {
+    if (cellDepsObj?.rgbpp) {
+      const { signet, testnet, mainnet } = cellDepsObj.rgbpp;
+      if (btcTestnetType === 'Signet') {
+        rgbppLockDep = signet;
+      } else {
+        rgbppLockDep = isMainnet ? mainnet : testnet;
+      }
+    }
     // RGB++ config cell is deployed together with the RGB++ lock contract
     //
     // contract_deployment_transaction:
@@ -98,6 +128,14 @@ export const fetchTypeIdCellDeps = async (
   }
 
   if (selected.btcTime === true) {
+    if (cellDepsObj?.btcTime) {
+      const { signet, testnet, mainnet } = cellDepsObj.btcTime;
+      if (btcTestnetType === 'Signet') {
+        btcTimeDep = signet;
+      } else {
+        btcTimeDep = isMainnet ? mainnet : testnet;
+      }
+    }
     // BTC Time config cell is deployed together with the BTC Time lock contract
     //
     // contract_deployment_transaction:
@@ -118,11 +156,24 @@ export const fetchTypeIdCellDeps = async (
   }
 
   if (selected.xudt === true) {
+    if (!isMainnet && cellDepsObj?.xudt) {
+      xudtDep = cellDepsObj.xudt.testnet;
+    }
     cellDeps = [...cellDeps, xudtDep] as CKBComponents.CellDep[];
   }
 
   if (selected.unique === true) {
+    if (!isMainnet && cellDepsObj?.unique) {
+      uniqueDep = cellDepsObj.unique.testnet;
+    }
     cellDeps = [...cellDeps, uniqueDep] as CKBComponents.CellDep[];
+  }
+
+  if (selected.utxoAirdropBadge === true) {
+    if (cellDepsObj?.utxoAirdropBadge) {
+      utxoAirdropBadgeDep = isMainnet ? cellDepsObj.utxoAirdropBadge.mainnet : cellDepsObj.utxoAirdropBadge.testnet;
+    }
+    cellDeps = [...cellDeps, utxoAirdropBadgeDep] as CKBComponents.CellDep[];
   }
 
   /**

--- a/packages/ckb/src/utils/ckb-tx.ts
+++ b/packages/ckb/src/utils/ckb-tx.ts
@@ -7,6 +7,7 @@ import {
   getClusterTypeScript,
   getCompatibleXudtTypeScripts,
   getSporeTypeScript,
+  getTokenMetadataTypeScript,
   getUtxoAirdropBadgeTypeScript,
   getXudtTypeScript,
 } from '../constants';
@@ -32,6 +33,15 @@ export const isUtxoAirdropBadgeType = (type: CKBComponents.Script, isMainnet: bo
     args: '',
   });
   return utxoAirdropBadgeType === typeAsset;
+};
+
+export const isTokenMetadataType = (type: CKBComponents.Script, isMainnet: boolean): boolean => {
+  const tokenMetadataType = serializeScript(getTokenMetadataTypeScript(isMainnet));
+  const typeAsset = serializeScript({
+    ...type,
+    args: '',
+  });
+  return tokenMetadataType === typeAsset;
 };
 
 export const isCompatibleUDTTypesSupported = (type: CKBComponents.Script, isMainnet: boolean): boolean => {

--- a/packages/ckb/src/utils/ckb-tx.ts
+++ b/packages/ckb/src/utils/ckb-tx.ts
@@ -7,6 +7,7 @@ import {
   getClusterTypeScript,
   getCompatibleXudtTypeScripts,
   getSporeTypeScript,
+  getUtxoAirdropBadgeTypeScript,
   getXudtTypeScript,
 } from '../constants';
 import { Hex, IndexerCell, RgbppTokenInfo } from '../types';
@@ -22,6 +23,15 @@ export const calculateTransactionFee = (txSize: number, feeRate?: bigint): bigin
   const base = BigInt(txSize) * rate;
   const fee = base / ratio;
   return fee * ratio < base ? fee + BigInt(1) : fee;
+};
+
+export const isUtxoAirdropBadgeType = (type: CKBComponents.Script, isMainnet: boolean): boolean => {
+  const utxoAirdropBadgeType = serializeScript(getUtxoAirdropBadgeTypeScript(isMainnet));
+  const typeAsset = serializeScript({
+    ...type,
+    args: '',
+  });
+  return utxoAirdropBadgeType === typeAsset;
 };
 
 export const isCompatibleUDTTypesSupported = (type: CKBComponents.Script, isMainnet: boolean): boolean => {


### PR DESCRIPTION
## Changes

- Add UTXOAirdropBadge Testnet deployment information
- Fetch UTXOAirdropBadge Testnet deployment information from GitHub and Vercel server
- Add `isUtxoAirdropBadgeType` and `isTokenMetadataType` for `btc-assets-api` to encode the token information and metadata of the UTXOAirdropBadge