### PR TITLE
refactor(ckb): encapsulate transaction fee supplementation methods

### DIFF
--- a/.changeset/tough-foxes-add.md
+++ b/.changeset/tough-foxes-add.md
@@ -1,0 +1,10 @@
+---
+'@rgbpp-sdk/ckb': minor
+---
+
+Encapsulate 3 methods for supplementing CKB transaction fees:
+- `appendOwnerCellToRgbppTx` for supplementing fees in RGB++ xUDT transactions;
+- `completeBtcTimeCellSpentTx` for BTC timelock unlock transaction building and fee supplementation;
+- `completeAppendingIssuerCellToSporesCreateTx` for supplementing fees in Spores creation transactions;
+
+Encapsulate `signCkbTransaction` method for signing CKB transactions.

--- a/.changeset/tough-foxes-add.md
+++ b/.changeset/tough-foxes-add.md
@@ -3,8 +3,8 @@
 ---
 
 Encapsulate 3 methods for supplementing CKB transaction fees:
-- `appendOwnerCellToRgbppTx` for supplementing fees in RGB++ xUDT transactions;
-- `completeBtcTimeCellSpentTx` for BTC timelock unlock transaction building and fee supplementation;
-- `completeAppendingIssuerCellToSporesCreateTx` for supplementing fees in Spores creation transactions;
+- `appendIssuerCellToBtcBatchTransferToSign` for supplementing fees in RGB++ xUDT transactions;
+- `prepareBtcTimeCellSpentUnsignedTx` for BTC timelock unlock transaction building and fee supplementation;
+- `appendIssuerCellToSporesCreateUnsignedTx` for supplementing fees in Spores creation transactions;
 
 Encapsulate `signCkbTransaction` method for signing CKB transactions.

--- a/examples/rgbpp/xudt/offline/1-prepare-launch.ts
+++ b/examples/rgbpp/xudt/offline/1-prepare-launch.ts
@@ -10,6 +10,7 @@ import {
   calculateTransactionFee,
   genRgbppLockScript,
   getSecp256k1CellDep,
+  signCkbTransaction,
 } from 'rgbpp/ckb';
 import { RGBPP_TOKEN_INFO } from './0-rgbpp-token-info';
 import {
@@ -75,15 +76,15 @@ const prepareLaunchCell = async ({
   changeCapacity -= estimatedTxFee;
   unsignedTx.outputs[unsignedTx.outputs.length - 1].capacity = append0x(changeCapacity.toString(16));
 
-  const signedTx = collector.getCkb().signTransaction(CKB_PRIVATE_KEY)(unsignedTx);
+  const signedTx = signCkbTransaction(CKB_PRIVATE_KEY, unsignedTx);
   const txHash = await collector.getCkb().rpc.sendTransaction(signedTx, 'passthrough');
 
   console.info(`Launch cell has been created and the CKB tx hash ${txHash}`);
 };
 
 prepareLaunchCell({
-  outIndex: 6,
-  btcTxId: '692a88b83d7dee2a77b5ab3372115a311aa503b1632d3ecdd2e77ffbafd94bdf',
+  outIndex: 3,
+  btcTxId: 'd6cbc8c4418cb1c4cab200c60e653ee886fd67d1c839197b1ac73a88a6360473',
   rgbppTokenInfo: RGBPP_TOKEN_INFO,
 });
 

--- a/examples/rgbpp/xudt/offline/2-launch-rgbpp.ts
+++ b/examples/rgbpp/xudt/offline/2-launch-rgbpp.ts
@@ -61,7 +61,7 @@ const launchRgppAsset = async ({ ownerRgbppLockArgs, launchAmount, rgbppTokenInf
     from: btcAccount.from,
     fromPubkey: btcAccount.fromPubkey,
     source: btcOfflineDataSource,
-    feeRate: 4096,
+    feeRate: 256,
   });
 
   const { txId: btcTxId, rawTxHex: btcTxBytes } = await signAndSendPsbt(psbt, btcAccount, btcService);
@@ -96,7 +96,7 @@ const launchRgppAsset = async ({ ownerRgbppLockArgs, launchAmount, rgbppTokenInf
 
 // rgbppLockArgs: outIndexU32 + btcTxId
 launchRgppAsset({
-  ownerRgbppLockArgs: buildRgbppLockArgs(6, '692a88b83d7dee2a77b5ab3372115a311aa503b1632d3ecdd2e77ffbafd94bdf'),
+  ownerRgbppLockArgs: buildRgbppLockArgs(3, 'd6cbc8c4418cb1c4cab200c60e653ee886fd67d1c839197b1ac73a88a6360473'),
   rgbppTokenInfo: RGBPP_TOKEN_INFO,
   // The total issuance amount of RGBPP Token, the decimal is determined by RGBPP Token info
   launchAmount: BigInt(2100_0000) * BigInt(10 ** RGBPP_TOKEN_INFO.decimal),

--- a/examples/rgbpp/xudt/offline/3-distribute-rgbpp.ts
+++ b/examples/rgbpp/xudt/offline/3-distribute-rgbpp.ts
@@ -21,7 +21,7 @@ import {
   sendCkbTx,
   updateCkbTxWithRealBtcTxId,
   genRgbppLockScript,
-  appendOwnerCellToRgbppTx,
+  appendIssuerCellToBtcBatchTransferToSign,
   addressToScriptHash,
   signCkbTransaction,
 } from 'rgbpp/ckb';
@@ -99,7 +99,7 @@ const distributeRgbppAssetOnBtc = async ({ rgbppLockArgsList, receivers, xudtTyp
         rgbppApiSpvProof,
       });
 
-      const { ckbRawTx: unsignedTx, inputCells } = await appendOwnerCellToRgbppTx({
+      const { ckbRawTx: unsignedTx, inputCells } = await appendIssuerCellToBtcBatchTransferToSign({
         issuerAddress: ckbAddress,
         ckbRawTx: ckbTx,
         collector: offlineCollector,

--- a/examples/rgbpp/xudt/offline/3-distribute-rgbpp.ts
+++ b/examples/rgbpp/xudt/offline/3-distribute-rgbpp.ts
@@ -16,12 +16,14 @@ import {
 import {
   RgbppBtcAddressReceiver,
   appendCkbTxWitnesses,
-  appendIssuerCellToBtcBatchTransfer,
   buildRgbppLockArgs,
   getXudtTypeScript,
   sendCkbTx,
   updateCkbTxWithRealBtcTxId,
   genRgbppLockScript,
+  appendOwnerCellToRgbppTx,
+  addressToScriptHash,
+  signCkbTransaction,
 } from 'rgbpp/ckb';
 import { saveCkbVirtualTxResult } from '../../shared/utils';
 import { signAndSendPsbt } from '../../shared/btc-account';
@@ -78,7 +80,7 @@ const distributeRgbppAssetOnBtc = async ({ rgbppLockArgsList, receivers, xudtTyp
     from: btcAccount.from,
     fromPubkey: btcAccount.fromPubkey,
     source: btcOfflineDataSource,
-    feeRate: 4096,
+    feeRate: 256,
   });
 
   const { txId: btcTxId, rawTxHex: btcTxBytes } = await signAndSendPsbt(psbt, btcAccount, btcService);
@@ -97,14 +99,17 @@ const distributeRgbppAssetOnBtc = async ({ rgbppLockArgsList, receivers, xudtTyp
         rgbppApiSpvProof,
       });
 
-      const signedTx = await appendIssuerCellToBtcBatchTransfer({
-        secp256k1PrivateKey: CKB_PRIVATE_KEY,
+      const { ckbRawTx: unsignedTx, inputCells } = await appendOwnerCellToRgbppTx({
         issuerAddress: ckbAddress,
         ckbRawTx: ckbTx,
         collector: offlineCollector,
         sumInputsCapacity,
         isMainnet,
       });
+
+      const keyMap = new Map<string, string>();
+      keyMap.set(addressToScriptHash(ckbAddress), CKB_PRIVATE_KEY);
+      const signedTx = signCkbTransaction(keyMap, unsignedTx, inputCells, true);
 
       const txHash = await sendCkbTx({ collector, signedTx });
       console.info(`RGB++ Asset has been distributed and CKB tx hash is ${txHash}`);
@@ -123,9 +128,9 @@ const distributeRgbppAssetOnBtc = async ({ rgbppLockArgsList, receivers, xudtTyp
 // rgbppLockArgs: outIndexU32 + btcTxId
 distributeRgbppAssetOnBtc({
   // Warning: If rgbpp assets are distributed continuously, then the position of the current rgbpp asset utxo depends on the position of the previous change utxo distributed
-  rgbppLockArgsList: [buildRgbppLockArgs(1, 'a2bcca7807f8543d71e85e772335fa7eec2d812ca3250fed96a9d406aa1a9827')],
+  rgbppLockArgsList: [buildRgbppLockArgs(1, '65e0574dfdbed4809736f3ec5a73aa191f147873d083ddb9978aecb969dd1900')],
   // The xudtTypeArgs comes from the logs "RGB++ Asset type script args" of 2-launch-rgbpp.ts
-  xudtTypeArgs: '0x13ce1d60ec65d693724006086568645aa24c019510ebc9af7cf6b993c2d7bffb',
+  xudtTypeArgs: '0xe402314a4b31223afe00a9c69c0b872863b990219525e1547ec05d9d88434b24',
   receivers: [
     {
       toBtcAddress: 'tb1qeq27se73d0e6zkh53e3xrj90vqzv8g7ja3nm85',

--- a/examples/rgbpp/xudt/offline/4-btc-leap-ckb.ts
+++ b/examples/rgbpp/xudt/offline/4-btc-leap-ckb.ts
@@ -2,7 +2,9 @@ import {
   buildRgbppLockArgs,
   getXudtTypeScript,
   genRgbppLockScript,
-  appendIssuerCellToBtcBatchTransfer,
+  appendOwnerCellToRgbppTx,
+  signCkbTransaction,
+  addressToScriptHash,
   appendCkbTxWitnesses,
   updateCkbTxWithRealBtcTxId,
   sendCkbTx,
@@ -71,7 +73,7 @@ const leapFromBtcToCKB = async ({ rgbppLockArgsList, toCkbAddress, xudtTypeArgs,
     fromPubkey: btcAccount.fromPubkey,
     source: btcOfflineDataSource,
     needPaymaster: false,
-    feeRate: 6000,
+    feeRate: 256,
   });
 
   const { txId: btcTxId, rawTxHex: btcTxBytes } = await signAndSendPsbt(psbt, btcAccount, btcService);
@@ -90,15 +92,17 @@ const leapFromBtcToCKB = async ({ rgbppLockArgsList, toCkbAddress, xudtTypeArgs,
         rgbppApiSpvProof,
       });
 
-      // pay tx fee
-      const signedTx = await appendIssuerCellToBtcBatchTransfer({
-        secp256k1PrivateKey: CKB_PRIVATE_KEY,
+      const { ckbRawTx: unsignedTx, inputCells } = await appendOwnerCellToRgbppTx({
         issuerAddress: ckbAddress,
         ckbRawTx: ckbTx,
         collector: offlineCollector,
         sumInputsCapacity,
         isMainnet,
       });
+
+      const keyMap = new Map<string, string>();
+      keyMap.set(addressToScriptHash(ckbAddress), CKB_PRIVATE_KEY);
+      const signedTx = signCkbTransaction(keyMap, unsignedTx, inputCells, true);
 
       const txHash = await sendCkbTx({ collector, signedTx });
       console.info(`Rgbpp asset has been jumped from BTC to CKB and the related CKB tx hash is ${txHash}`);
@@ -116,11 +120,11 @@ const leapFromBtcToCKB = async ({ rgbppLockArgsList, toCkbAddress, xudtTypeArgs,
 
 // rgbppLockArgs: outIndexU32 + btcTxId
 leapFromBtcToCKB({
-  rgbppLockArgsList: [buildRgbppLockArgs(5, '316267e33808ae437c9870c3538ec5d46361e6474ace0e150442b10c41a1cb21')],
+  rgbppLockArgsList: [buildRgbppLockArgs(1, 'dfb3be075b831ce7605ab3f56b7dda39ba7438e015ded3332db1f54cfac161de')],
   toCkbAddress: 'ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqfpu7pwavwf3yang8khrsklumayj6nyxhqpmh7fq',
   // Please use your own RGB++ xudt asset's xudtTypeArgs
-  xudtTypeArgs: '0x13ce1d60ec65d693724006086568645aa24c019510ebc9af7cf6b993c2d7bffb',
-  transferAmount: BigInt(233_0000_0000),
+  xudtTypeArgs: '0xe402314a4b31223afe00a9c69c0b872863b990219525e1547ec05d9d88434b24',
+  transferAmount: BigInt(100_0000_0000),
 });
 
 /* 

--- a/examples/rgbpp/xudt/offline/4-btc-leap-ckb.ts
+++ b/examples/rgbpp/xudt/offline/4-btc-leap-ckb.ts
@@ -2,7 +2,7 @@ import {
   buildRgbppLockArgs,
   getXudtTypeScript,
   genRgbppLockScript,
-  appendOwnerCellToRgbppTx,
+  appendIssuerCellToBtcBatchTransferToSign,
   signCkbTransaction,
   addressToScriptHash,
   appendCkbTxWitnesses,
@@ -92,7 +92,7 @@ const leapFromBtcToCKB = async ({ rgbppLockArgsList, toCkbAddress, xudtTypeArgs,
         rgbppApiSpvProof,
       });
 
-      const { ckbRawTx: unsignedTx, inputCells } = await appendOwnerCellToRgbppTx({
+      const { ckbRawTx: unsignedTx, inputCells } = await appendIssuerCellToBtcBatchTransferToSign({
         issuerAddress: ckbAddress,
         ckbRawTx: ckbTx,
         collector: offlineCollector,

--- a/examples/rgbpp/xudt/offline/5-unlock-btc-time-cell.ts
+++ b/examples/rgbpp/xudt/offline/5-unlock-btc-time-cell.ts
@@ -1,5 +1,12 @@
-import { buildBtcTimeCellsSpentTx, signBtcTimeCellSpentTx } from 'rgbpp';
-import { sendCkbTx, getBtcTimeLockScript, btcTxIdAndAfterFromBtcTimeLockArgs } from 'rgbpp/ckb';
+import { buildBtcTimeCellsSpentTx } from 'rgbpp';
+import {
+  sendCkbTx,
+  getBtcTimeLockScript,
+  btcTxIdAndAfterFromBtcTimeLockArgs,
+  completeBtcTimeCellSpentTx,
+  addressToScriptHash,
+  signCkbTransaction,
+} from 'rgbpp/ckb';
 import { BTC_TESTNET_TYPE, CKB_PRIVATE_KEY, btcService, ckbAddress, collector, isMainnet } from '../../env';
 import { OfflineBtcAssetsDataSource, SpvProofEntry } from 'rgbpp/service';
 
@@ -38,13 +45,16 @@ const unlockBtcTimeCell = async ({ btcTimeCellArgs }: { btcTimeCellArgs: string 
     btcTestnetType: BTC_TESTNET_TYPE,
   });
 
-  const signedTx = await signBtcTimeCellSpentTx({
-    secp256k1PrivateKey: CKB_PRIVATE_KEY,
+  const { ckbRawTx: unsignedTx, inputCells } = await completeBtcTimeCellSpentTx({
     collector,
     masterCkbAddress: ckbAddress,
     ckbRawTx,
     isMainnet,
   });
+
+  const keyMap = new Map<string, string>();
+  keyMap.set(addressToScriptHash(ckbAddress), CKB_PRIVATE_KEY);
+  const signedTx = signCkbTransaction(keyMap, unsignedTx, inputCells, true);
 
   const txHash = await sendCkbTx({ collector, signedTx });
   console.info(`BTC time cell has been spent and CKB tx hash is ${txHash}`);
@@ -53,5 +63,9 @@ const unlockBtcTimeCell = async ({ btcTimeCellArgs }: { btcTimeCellArgs: string 
 // The btcTimeCellArgs is from the outputs[0].lock.args(BTC Time lock args) of the 3-btc-leap-ckb.ts CKB transaction
 unlockBtcTimeCell({
   btcTimeCellArgs:
-    '0x7d00000010000000590000005d000000490000001000000030000000310000009bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8011400000021e782eeb1c9893b341ed71c2dfe6fa496a6435c0600000045241651e435d786d0ba8a1280d4bb3283eca10db728e2ba0a3978c136f5bb19',
+    '0x7d00000010000000590000005d000000490000001000000030000000310000009bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8011400000021e782eeb1c9893b341ed71c2dfe6fa496a6435c06000000f2aa85670171e5727da232e041e194508b0beced672e731f638ff84abf8d5ff8',
 });
+
+/* 
+npx tsx examples/rgbpp/xudt/offline/5-unlock-btc-time-cell.ts
+*/

--- a/examples/rgbpp/xudt/offline/5-unlock-btc-time-cell.ts
+++ b/examples/rgbpp/xudt/offline/5-unlock-btc-time-cell.ts
@@ -3,7 +3,7 @@ import {
   sendCkbTx,
   getBtcTimeLockScript,
   btcTxIdAndAfterFromBtcTimeLockArgs,
-  completeBtcTimeCellSpentTx,
+  prepareBtcTimeCellSpentUnsignedTx,
   addressToScriptHash,
   signCkbTransaction,
 } from 'rgbpp/ckb';
@@ -45,7 +45,7 @@ const unlockBtcTimeCell = async ({ btcTimeCellArgs }: { btcTimeCellArgs: string 
     btcTestnetType: BTC_TESTNET_TYPE,
   });
 
-  const { ckbRawTx: unsignedTx, inputCells } = await completeBtcTimeCellSpentTx({
+  const { ckbRawTx: unsignedTx, inputCells } = await prepareBtcTimeCellSpentUnsignedTx({
     collector,
     masterCkbAddress: ckbAddress,
     ckbRawTx,

--- a/examples/rgbpp/xudt/offline/6-ckb-leap-btc.ts
+++ b/examples/rgbpp/xudt/offline/6-ckb-leap-btc.ts
@@ -1,6 +1,6 @@
 import { addressToScript, serializeScript } from '@nervosnetwork/ckb-sdk-utils';
 import { genCkbJumpBtcVirtualTx } from 'rgbpp';
-import { getSecp256k1CellDep, buildRgbppLockArgs, getXudtTypeScript } from 'rgbpp/ckb';
+import { getSecp256k1CellDep, buildRgbppLockArgs, getXudtTypeScript, signCkbTransaction } from 'rgbpp/ckb';
 import {
   CKB_PRIVATE_KEY,
   isMainnet,
@@ -49,8 +49,7 @@ const leapFromCkbToBtc = async ({ outIndex, btcTxId, xudtTypeArgs, transferAmoun
     witnesses: [emptyWitness, ...ckbRawTx.witnesses.slice(1)],
   };
 
-  const signedTx = collector.getCkb().signTransaction(CKB_PRIVATE_KEY)(unsignedTx);
-
+  const signedTx = signCkbTransaction(CKB_PRIVATE_KEY, unsignedTx);
   const txHash = await collector.getCkb().rpc.sendTransaction(signedTx, 'passthrough');
   console.info(`Rgbpp asset has been jumped from CKB to BTC and CKB tx hash is ${txHash}`);
 };
@@ -62,10 +61,10 @@ leapFromCkbToBtc({
   outIndex: 0,
   btcTxId: 'c1db31abe6bab345b5d5ab4a19c8f34c8cfe23efa4ec6bfa7b05c8e7b4f965b8',
   // Please use your own RGB++ xudt asset's xudtTypeArgs
-  xudtTypeArgs: '0x13ce1d60ec65d693724006086568645aa24c019510ebc9af7cf6b993c2d7bffb',
+  xudtTypeArgs: '0xe402314a4b31223afe00a9c69c0b872863b990219525e1547ec05d9d88434b24',
   transferAmount: BigInt(10_0000_0000),
 });
 
 /* 
-npx tsx examples/rgbpp/xudt/offline/5-ckb-leap-btc.ts
+npx tsx examples/rgbpp/xudt/offline/6-ckb-leap-btc.ts
 */

--- a/packages/ckb/src/rgbpp/btc-time.ts
+++ b/packages/ckb/src/rgbpp/btc-time.ts
@@ -116,7 +116,7 @@ export const buildBtcTimeCellsSpentTx = async ({
   return ckbTx;
 };
 
-export const completeBtcTimeCellSpentTx = async ({
+export const prepareBtcTimeCellSpentUnsignedTx = async ({
   ckbRawTx,
   collector,
   masterCkbAddress,
@@ -184,7 +184,7 @@ export const signBtcTimeCellSpentTx = async ({
   outputCapacityRange,
   ckbFeeRate,
 }: SignBtcTimeCellsTxParams): Promise<CKBComponents.RawTransaction> => {
-  const { ckbRawTx: rawTx, inputCells } = await completeBtcTimeCellSpentTx({
+  const { ckbRawTx: rawTx, inputCells } = await prepareBtcTimeCellSpentUnsignedTx({
     ckbRawTx,
     collector,
     masterCkbAddress,

--- a/packages/ckb/src/rgbpp/btc-transfer.ts
+++ b/packages/ckb/src/rgbpp/btc-transfer.ts
@@ -353,7 +353,7 @@ export const genBtcBatchTransferCkbVirtualTx = async ({
  * @param isMainnet True is for BTC and CKB Mainnet, false is for BTC and CKB Testnet
  * @returns The updated transaction and input cells information
  */
-export const appendOwnerCellToRgbppTx = async ({
+export const appendIssuerCellToBtcBatchTransferToSign = async ({
   issuerAddress,
   collector,
   ckbRawTx,
@@ -432,7 +432,7 @@ export const appendIssuerCellToBtcBatchTransfer = async ({
   isMainnet,
   ckbFeeRate,
 }: AppendIssuerCellToBtcBatchTransfer): Promise<CKBComponents.RawTransaction> => {
-  const { ckbRawTx: rawTx, inputCells } = await appendOwnerCellToRgbppTx({
+  const { ckbRawTx: rawTx, inputCells } = await appendIssuerCellToBtcBatchTransferToSign({
     issuerAddress,
     collector,
     ckbRawTx,

--- a/packages/ckb/src/rgbpp/btc-transfer.ts
+++ b/packages/ckb/src/rgbpp/btc-transfer.ts
@@ -25,6 +25,8 @@ import {
   throwErrorWhenRgbppCellsInvalid,
   throwErrorWhenTxInputsExceeded,
   isStandardUDTTypeSupported,
+  signCkbTransaction,
+  addressToScriptHash,
 } from '../utils';
 import { Hex, IndexerCell } from '../types';
 import {
@@ -36,14 +38,7 @@ import {
   getSecp256k1CellDep,
 } from '../constants';
 import { blockchain } from '@ckb-lumos/base';
-import signWitnesses from '@nervosnetwork/ckb-sdk-core/lib/signWitnesses';
-import {
-  addressToScript,
-  getTransactionSize,
-  rawTransactionToHash,
-  scriptToHash,
-  serializeWitnessArgs,
-} from '@nervosnetwork/ckb-sdk-utils';
+import { addressToScript, getTransactionSize } from '@nervosnetwork/ckb-sdk-utils';
 
 /**
  * Generate the virtual ckb transaction for the btc transfer tx
@@ -348,27 +343,29 @@ export const genBtcBatchTransferCkbVirtualTx = async ({
 };
 
 /**
- * Append paymaster cell to the ckb transaction inputs and sign the transaction with paymaster cell's secp256k1 private key
- * @param secp256k1PrivateKey The Secp256k1 private key of the paymaster cells maintainer
- * @param issuerAddress The issuer ckb address
+ * Appends cells from the issuer address to cover transaction fees and ensures sufficient capacity
+ * @param issuerAddress The address that provides cells for transaction fees
  * @param collector The collector that collects CKB live cells and transactions
- * @param ckbRawTx CKB raw transaction
+ * @param ckbRawTx The raw transaction to append cells to
  * @param sumInputsCapacity The sum capacity of ckb inputs which is to be used to calculate ckb tx fee
- * @param isMainnet True is for BTC and CKB Mainnet, false is for BTC and CKB Testnet
+ * @param sumInputsCapacity The total capacity of existing inputs
  * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
+ * @param isMainnet True is for BTC and CKB Mainnet, false is for BTC and CKB Testnet
+ * @returns The updated transaction and input cells information
  */
-export const appendIssuerCellToBtcBatchTransfer = async ({
-  secp256k1PrivateKey,
+export const appendOwnerCellToRgbppTx = async ({
   issuerAddress,
   collector,
   ckbRawTx,
   sumInputsCapacity,
-  isMainnet,
   ckbFeeRate,
-}: AppendIssuerCellToBtcBatchTransfer): Promise<CKBComponents.RawTransaction> => {
+  isMainnet,
+}: Omit<AppendIssuerCellToBtcBatchTransfer, 'secp256k1PrivateKey'>): Promise<{
+  ckbRawTx: CKBComponents.RawTransactionToSign;
+  inputCells: { outPoint: CKBComponents.OutPoint; lock: CKBComponents.Script }[];
+}> => {
+  const rgbppInputsLength = ckbRawTx.inputs.length;
   const rawTx = ckbRawTx as CKBComponents.RawTransactionToSign;
-
-  const rgbppInputsLength = rawTx.inputs.length;
 
   const sumOutputsCapacity: bigint = rawTx.outputs
     .map((output) => BigInt(output.capacity))
@@ -403,12 +400,9 @@ export const appendIssuerCellToBtcBatchTransfer = async ({
   changeCapacity -= estimatedTxFee;
   rawTx.outputs[rawTx.outputs.length - 1].capacity = append0x(changeCapacity.toString(16));
 
-  const keyMap = new Map<string, string>();
-  keyMap.set(scriptToHash(issuerLock), secp256k1PrivateKey);
-
   const issuerCellIndex = rgbppInputsLength;
   const cells = rawTx.inputs.map((input, index) => ({
-    outPoint: input.previousOutput,
+    outPoint: input.previousOutput as CKBComponents.OutPoint,
     lock: index >= issuerCellIndex ? issuerLock : getRgbppLockScript(isMainnet),
   }));
 
@@ -416,19 +410,39 @@ export const appendIssuerCellToBtcBatchTransfer = async ({
   const issuerWitnesses = rawTx.inputs.slice(rgbppInputsLength).map((_, index) => (index === 0 ? emptyWitness : '0x'));
   rawTx.witnesses = [...rawTx.witnesses, ...issuerWitnesses];
 
-  const transactionHash = rawTransactionToHash(rawTx);
-  const signedWitnesses = signWitnesses(keyMap)({
-    transactionHash,
-    witnesses: rawTx.witnesses,
-    inputCells: cells,
-    skipMissingKeys: true,
+  return { ckbRawTx: rawTx, inputCells: cells };
+};
+
+/**
+ * Append paymaster cell to the ckb transaction inputs and sign the transaction with paymaster cell's secp256k1 private key
+ * @param secp256k1PrivateKey The Secp256k1 private key of the paymaster cells maintainer
+ * @param issuerAddress The issuer ckb address
+ * @param collector The collector that collects CKB live cells and transactions
+ * @param ckbRawTx CKB raw transaction
+ * @param sumInputsCapacity The sum capacity of ckb inputs which is to be used to calculate ckb tx fee
+ * @param isMainnet True is for BTC and CKB Mainnet, false is for BTC and CKB Testnet
+ * @param ckbFeeRate The CKB transaction fee rate, default value is 1100
+ */
+export const appendIssuerCellToBtcBatchTransfer = async ({
+  secp256k1PrivateKey,
+  issuerAddress,
+  collector,
+  ckbRawTx,
+  sumInputsCapacity,
+  isMainnet,
+  ckbFeeRate,
+}: AppendIssuerCellToBtcBatchTransfer): Promise<CKBComponents.RawTransaction> => {
+  const { ckbRawTx: rawTx, inputCells } = await appendOwnerCellToRgbppTx({
+    issuerAddress,
+    collector,
+    ckbRawTx,
+    sumInputsCapacity,
+    ckbFeeRate,
+    isMainnet,
   });
 
-  const signedTx = {
-    ...rawTx,
-    witnesses: signedWitnesses.map((witness) =>
-      typeof witness !== 'string' ? serializeWitnessArgs(witness) : witness,
-    ),
-  };
-  return signedTx;
+  const keyMap = new Map<string, string>();
+  keyMap.set(addressToScriptHash(issuerAddress), secp256k1PrivateKey);
+
+  return signCkbTransaction(keyMap, rawTx, inputCells, true);
 };

--- a/packages/ckb/src/spore/spore.ts
+++ b/packages/ckb/src/spore/spore.ts
@@ -205,7 +205,7 @@ export const buildAppendingIssuerCellToSporesCreateTx = async ({
   return rawTx;
 };
 
-export const completeAppendingIssuerCellToSporesCreateTx = async ({
+export const appendIssuerCellToSporesCreateUnsignedTx = async ({
   ckbRawTx,
   isMainnet,
   issuerAddress,
@@ -269,7 +269,7 @@ export const appendIssuerCellToSporesCreate = async ({
   isMainnet,
   ckbFeeRate,
 }: AppendIssuerCellToSporeCreate): Promise<CKBComponents.RawTransaction> => {
-  const { ckbRawTx: rawTx, inputCells } = await completeAppendingIssuerCellToSporesCreateTx({
+  const { ckbRawTx: rawTx, inputCells } = await appendIssuerCellToSporesCreateUnsignedTx({
     ckbRawTx,
     isMainnet,
     issuerAddress,

--- a/packages/ckb/src/spore/spore.ts
+++ b/packages/ckb/src/spore/spore.ts
@@ -13,6 +13,8 @@ import {
   generateSporeId,
   generateSporeTransferCoBuild,
   throwErrorWhenSporeCellsInvalid,
+  addressToScriptHash,
+  signCkbTransaction,
 } from '../utils';
 import {
   AppendIssuerCellToSporeCreate,
@@ -41,15 +43,7 @@ import {
   RgbppUtxoBindMultiTypeAssetsError,
   TypeAssetNotSupportedError,
 } from '../error';
-import signWitnesses from '@nervosnetwork/ckb-sdk-core/lib/signWitnesses';
-import {
-  addressToScript,
-  bytesToHex,
-  getTransactionSize,
-  rawTransactionToHash,
-  scriptToHash,
-  serializeWitnessArgs,
-} from '@nervosnetwork/ckb-sdk-utils';
+import { addressToScript, bytesToHex, getTransactionSize } from '@nervosnetwork/ckb-sdk-utils';
 
 /**
  * Generate the virtual ckb transaction for creating spores
@@ -211,6 +205,51 @@ export const buildAppendingIssuerCellToSporesCreateTx = async ({
   return rawTx;
 };
 
+export const completeAppendingIssuerCellToSporesCreateTx = async ({
+  ckbRawTx,
+  isMainnet,
+  issuerAddress,
+  collector,
+  sumInputsCapacity,
+  ckbFeeRate,
+}: Omit<AppendIssuerCellToSporeCreate, 'secp256k1PrivateKey'>): Promise<{
+  ckbRawTx: CKBComponents.RawTransactionToSign;
+  inputCells: { outPoint: CKBComponents.OutPoint; lock: CKBComponents.Script }[];
+}> => {
+  const rgbppInputsLength = ckbRawTx.inputs.length;
+
+  const rawTx = await buildAppendingIssuerCellToSporesCreateTx({
+    issuerAddress,
+    collector,
+    ckbRawTx,
+    sumInputsCapacity,
+    ckbFeeRate,
+  });
+
+  rawTx.cellDeps = [...rawTx.cellDeps, getSecp256k1CellDep(isMainnet)];
+
+  const issuerLock = addressToScript(issuerAddress);
+
+  const issuerCellIndex = rgbppInputsLength;
+  const cells = rawTx.inputs.map((input, index) => ({
+    outPoint: input.previousOutput as CKBComponents.OutPoint,
+    lock: index >= issuerCellIndex ? issuerLock : getRgbppLockScript(isMainnet),
+  }));
+
+  const emptyWitness = { lock: '', inputType: '', outputType: '' };
+  const issuerWitnesses = rawTx.inputs.slice(rgbppInputsLength).map((_, index) => (index === 0 ? emptyWitness : '0x'));
+
+  const lastRawTxWitnessIndex = rawTx.witnesses.length - 1;
+  rawTx.witnesses = [
+    ...rawTx.witnesses.slice(0, lastRawTxWitnessIndex),
+    ...issuerWitnesses,
+    // The cobuild witness will be placed to the tail of the witnesses
+    rawTx.witnesses[lastRawTxWitnessIndex],
+  ];
+
+  return { ckbRawTx: rawTx, inputCells: cells };
+};
+
 /**
  * Append paymaster cell to the ckb transaction inputs and sign the transaction with paymaster cell's secp256k1 private key
  * @param secp256k1PrivateKey The Secp256k1 private key of the paymaster cells maintainer
@@ -230,55 +269,18 @@ export const appendIssuerCellToSporesCreate = async ({
   isMainnet,
   ckbFeeRate,
 }: AppendIssuerCellToSporeCreate): Promise<CKBComponents.RawTransaction> => {
-  const rgbppInputsLength = ckbRawTx.inputs.length;
-
-  const rawTx = await buildAppendingIssuerCellToSporesCreateTx({
+  const { ckbRawTx: rawTx, inputCells } = await completeAppendingIssuerCellToSporesCreateTx({
+    ckbRawTx,
+    isMainnet,
     issuerAddress,
     collector,
-    ckbRawTx,
     sumInputsCapacity,
     ckbFeeRate,
   });
 
-  rawTx.cellDeps = [...rawTx.cellDeps, getSecp256k1CellDep(isMainnet)];
-
-  const issuerLock = addressToScript(issuerAddress);
-
   const keyMap = new Map<string, string>();
-  keyMap.set(scriptToHash(issuerLock), secp256k1PrivateKey);
-
-  const issuerCellIndex = rgbppInputsLength;
-  const cells = rawTx.inputs.map((input, index) => ({
-    outPoint: input.previousOutput,
-    lock: index >= issuerCellIndex ? issuerLock : getRgbppLockScript(isMainnet),
-  }));
-
-  const emptyWitness = { lock: '', inputType: '', outputType: '' };
-  const issuerWitnesses = rawTx.inputs.slice(rgbppInputsLength).map((_, index) => (index === 0 ? emptyWitness : '0x'));
-
-  const lastRawTxWitnessIndex = rawTx.witnesses.length - 1;
-  rawTx.witnesses = [
-    ...rawTx.witnesses.slice(0, lastRawTxWitnessIndex),
-    ...issuerWitnesses,
-    // The cobuild witness will be placed to the tail of the witnesses
-    rawTx.witnesses[lastRawTxWitnessIndex],
-  ];
-
-  const transactionHash = rawTransactionToHash(rawTx);
-  const signedWitnesses = signWitnesses(keyMap)({
-    transactionHash,
-    witnesses: rawTx.witnesses,
-    inputCells: cells,
-    skipMissingKeys: true,
-  });
-
-  const signedTx = {
-    ...rawTx,
-    witnesses: signedWitnesses.map((witness) =>
-      typeof witness !== 'string' ? serializeWitnessArgs(witness) : witness,
-    ),
-  };
-  return signedTx;
+  keyMap.set(addressToScriptHash(issuerAddress), secp256k1PrivateKey);
+  return signCkbTransaction(keyMap, rawTx, inputCells, true);
 };
 
 /**

--- a/packages/ckb/src/utils/ckb-tx.ts
+++ b/packages/ckb/src/utils/ckb-tx.ts
@@ -247,20 +247,6 @@ export const checkCkbTxInputsCapacitySufficient = async (
 };
 
 export function signCkbTransaction(
-  key: string,
-  ckbTx: CKBComponents.RawTransactionToSign,
-  inputCells?: { outPoint: CKBComponents.OutPoint; lock: CKBComponents.Script }[],
-  skipMissingKeys?: boolean,
-): CKBComponents.RawTransaction;
-
-export function signCkbTransaction(
-  key: Map<string, string>,
-  ckbTx: CKBComponents.RawTransactionToSign,
-  inputCells: { outPoint: CKBComponents.OutPoint; lock: CKBComponents.Script }[],
-  skipMissingKeys?: boolean,
-): CKBComponents.RawTransaction;
-
-export function signCkbTransaction(
   key: string | Map<string, string>,
   ckbTx: CKBComponents.RawTransactionToSign,
   inputCells: { outPoint: CKBComponents.OutPoint; lock: CKBComponents.Script }[] = [],
@@ -278,6 +264,7 @@ export function signCkbTransaction(
     skipMissingKeys,
   });
 
+  // Serialize the witness args if needed to ensure all witnesses are consistently in string format
   return {
     ...ckbTx,
     witnesses: signedWitnesses.map((witness) =>
@@ -289,14 +276,4 @@ export function signCkbTransaction(
 export const addressToScriptHash = (address: string) => {
   const script = addressToScript(address);
   return scriptToHash(script);
-};
-
-// Normalizes a CKB transaction to be signed by ensuring all witnesses are in serialized string format.
-export const normalizeCkbTxToSign = (ckbTx: CKBComponents.RawTransactionToSign): CKBComponents.RawTransactionToSign => {
-  return {
-    ...ckbTx,
-    witnesses: ckbTx.witnesses.map((witness) =>
-      typeof witness !== 'string' ? serializeWitnessArgs(witness) : witness,
-    ),
-  };
 };


### PR DESCRIPTION
Extract the logic for supplementing transaction fees into separate methods to facilitate users handling the signing logic for the final CKB transaction on their own.

xUDT testing transactions on Testnet3 in offline mode:
1. Issuance preparation 
   - CKB tx: https://testnet.explorer.nervos.org/transaction/0x24d5da586b046475959271f4a23458b9b3569babeccaf5857f1659791a856d43
2. Issuance:
   - BTC tx: https://mempool.space/testnet/tx/65e0574dfdbed4809736f3ec5a73aa191f147873d083ddb9978aecb969dd1900
   - CKB tx: https://testnet.explorer.nervos.org/transaction/0xc323ee59b725a5b067df10360fe4b675bd1079f90473a4bb19ce8650c51a9759
3. Distribution:
   - BTC tx: https://mempool.space/testnet/tx/dfb3be075b831ce7605ab3f56b7dda39ba7438e015ded3332db1f54cfac161de
   - CKB tx: https://testnet.explorer.nervos.org/transaction/0xfadb79b71493ffb07241e74e53c8ac77a4d302df671c35d5ad8dbf527a8e82f5
4. Jumping from BTC to CKB:
   - BTC tx: https://mempool.space/testnet/tx/f85f8dbf4af88f631f732e67edec0b8b5094e141e032a27d72e571016785aaf2
   - CKB tx: https://testnet.explorer.nervos.org/transaction/0x3fd3867403bd238bb1492a44d27f52b98894503d7986b94e99b811ff80a35cd4
5. Unlock BTC time lock cell:
   - CKB tx: https://testnet.explorer.nervos.org/transaction/0x6ed2a429d5b913d7f514f392b2478e1b4ddac1f78ab1418df9d3bdb83f4cbed0


xUDT testing transactions on Testnet3 in default mode:
- Distribution:
  - BTC tx: https://mempool.space/testnet/tx/f4e47ab2a0ee9e80ea20e284b72e6b803b2cff75e44df977df6d53d209f4d92b
  - CKB tx: https://testnet.explorer.nervos.org/transaction/0x4cb50aa75afa245ab0bf65d9de3f5afa255e7f5456a559289734f60560bafccf
- Unlock BTC time lock cell:
  - CKB tx: https://testnet.explorer.nervos.org/transaction/0xc68f3ea6333627ab9a69bf9a1870e3ae420da60ba87f21d4a9559a2622ba4640

Spore Creation:
- BTC tx: https://mempool.space/testnet/tx/3dafaf0902f7a534545d93900731611e98b39d92cc7c9196e858d858a15737d4
- CKB tx: https://testnet.explorer.nervos.org/transaction/0xf52746a9a939c133140ac06923ce38f2acf117d40b83b32b3dddc522e4312b19