### PR TITLE
test: use fastestFee * 1.1 as basic btc-fee for integration-tests

### DIFF
--- a/tests/rgbpp/shared/utils.ts
+++ b/tests/rgbpp/shared/utils.ts
@@ -7,7 +7,8 @@ export const network = 'testnet';
 
 export async function getFastestFeeRate() {
   const fees = await btcService.getBtcRecommendedFeeRates();
-  return fees.fastestFee + 1000;
+  // return fees.fastestFee + 1000;
+  return Math.ceil(fees.fastestFee * 1.1);
 }
 
 export async function writeStepLog(step: string, data: string | object) {


### PR DESCRIPTION
## Changes

- Update the basic fee rate for integration-tests from `fastestFee + 1000` to `fastestFee * 1.1`